### PR TITLE
✨ Conditional tabix

### DIFF
--- a/tools/tabix_index.cwl
+++ b/tools/tabix_index.cwl
@@ -1,0 +1,32 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: tabix_index 
+doc: >-
+  This tool will run tabix conditionally dependent on whether an index is provided.
+  The tool will output the input_file with the index, provided or created within, as a secondary file.
+requirements:
+  - class: ShellCommandRequirement
+  - class: DockerRequirement
+    dockerPull: 'kfdrc/samtools:1.9'
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+  - class: InitialWorkDirRequirement
+    listing: [$(inputs.input_file),$(inputs.input_index)]
+
+baseCommand: []
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >-
+      $(inputs.input_index ? 'echo tabix' : 'tabix')
+
+inputs:
+  input_file: { type: 'File', doc: "Position sorted and compressed by bgzip input file", inputBinding: { position: 1, shellQuote: false } }
+  input_index: { type: 'File?', doc: "Index file for the input_file, if one exists" }
+
+outputs:
+  output: 
+    type: File
+    outputBinding:
+      glob: $(inputs.input_file.basename) 
+    secondaryFiles: [.tbi]


### PR DESCRIPTION
## Description

Added a simple tabix indexing tool that will take a file and optional index.
If the index is missing it will generate one.
The tool then returns the file with the index (provided or generated within) as a secondaryFile.

Part of: https://github.com/d3b-center/bixu-tracker/issues/594

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run tool with only input_file
- [x] Run tool with both input_file and input_index 

**Test Configuration**:
* Environment: Local docker env using Rabix 1.0.5 and cwltool 3.0.20200324120055
* Test files: https://cavatica.sbgenomics.com/public/files/5ba3cd8d0bdb24eefb7d2fd5/

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
