### PR TITLE
🐛 bind input fasta

### DIFF
--- a/tools/bwa_index.cwl
+++ b/tools/bwa_index.cwl
@@ -26,7 +26,7 @@ arguments:
       index -6 -a bwtsw 
 inputs:
   generate_bwa_indexes: { type: 'boolean?' }
-  input_fasta: { type: File, inputBinding: { position: 2 } }
+  input_fasta: { type: File, inputBinding: { position: 2, valueFrom: $(self.basename) } }
   input_alt: { type: 'File?' }
   input_amb: { type: 'File?' }
   input_ann: { type: 'File?' }

--- a/tools/bwa_index.cwl
+++ b/tools/bwa_index.cwl
@@ -10,7 +10,7 @@ requirements:
   - class: ShellCommandRequirement
   - class: ResourceRequirement
   - class: InitialWorkDirRequirement
-    listing: [$(inputs.input_alt),$(inputs.input_amb),$(inputs.input_ann),$(inputs.input_bwt),$(inputs.input_pac),$(inputs.input_sa)]
+    listing: [$(inputs.input_fasta),$(inputs.input_alt),$(inputs.input_amb),$(inputs.input_ann),$(inputs.input_bwt),$(inputs.input_pac),$(inputs.input_sa)]
   - class: DockerRequirement
     dockerPull: 'kfdrc/bwa:0.7.17-dev'
   - class: InlineJavascriptRequirement


### PR DESCRIPTION
## Description

BWA index will generate the indexes in the directory of the file it is indexing. This presents problems in two ways:
1. In cwltool that is a readonly env and will throw a segmentation fault
1. glob cannot access the files there

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Already tested for alignment and in master: https://github.com/kids-first/kf-alignment-workflow/blob/master/tools/bwa_index.cwl

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings