### PR TITLE
🐳 dockerPull from new registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This workflow is the current production workflow, equivalent to this [Cavatica p
     -  wgs_evaluation_regions.hg38.interval_list
 
 ## Other Resources
-- tool images: https://hub.docker.com/r/kfdrc/
 - dockerfiles: https://github.com/d3b-center/bixtools
 
 ![pipeline flowchart](https://github.com/kids-first/kf-jointgenotyping-workflow/blob/master/docs/kfdrc-jointgenotyping-refinement-workflow.png?raw=true "Joint Genotyping Workflow")

--- a/tools/bwa_index.cwl
+++ b/tools/bwa_index.cwl
@@ -12,7 +12,7 @@ requirements:
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_fasta),$(inputs.input_alt),$(inputs.input_amb),$(inputs.input_ann),$(inputs.input_bwt),$(inputs.input_pac),$(inputs.input_sa)]
   - class: DockerRequirement
-    dockerPull: 'kfdrc/bwa:0.7.17-dev'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/bwa:0.7.17-r1188'
   - class: InlineJavascriptRequirement
 baseCommand: []
 arguments:

--- a/tools/gatk_applyrecalibration.cwl
+++ b/tools/gatk_applyrecalibration.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_applyrecalibration
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_calculategenotypeposteriors.cwl
+++ b/tools/gatk_calculategenotypeposteriors.cwl
@@ -9,7 +9,7 @@ requirements:
     coresMin: 2
     coresMax: 4
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
 baseCommand: [/gatk]
 arguments:
   - position: 1

--- a/tools/gatk_gatherfinalvcf.cwl
+++ b/tools/gatk_gatherfinalvcf.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_gathervcfs
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_gathertranches.cwl
+++ b/tools/gatk_gathertranches.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_gathertranches
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: ResourceRequirement
     ramMin: 7000

--- a/tools/gatk_gathervcfs.cwl
+++ b/tools/gatk_gathervcfs.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_gathervcfs
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_import_genotype_filtergvcf_merge.cwl
+++ b/tools/gatk_import_genotype_filtergvcf_merge.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_import_genotype_filtergvcf_merge
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_indelsvariantrecalibrator.cwl
+++ b/tools/gatk_indelsvariantrecalibrator.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_indelsvariantrecalibrator
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_indexfeaturefile.cwl
+++ b/tools/gatk_indexfeaturefile.cwl
@@ -4,7 +4,7 @@ id: gatk_indexfeaturefile
 doc: "Creates an index for a feature file, e.g. VCF or BED file."
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_file),$(inputs.input_index)]
   - class: InlineJavascriptRequirement

--- a/tools/gatk_snpsvariantrecalibratorcreatemodel.cwl
+++ b/tools/gatk_snpsvariantrecalibratorcreatemodel.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_snpsvariantrecalibratorcreatemodel
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_snpsvariantrecalibratorscattered.cwl
+++ b/tools/gatk_snpsvariantrecalibratorscattered.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: gatk_snpsvariantrecalibratorscattered
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement

--- a/tools/gatk_variantannotator.cwl
+++ b/tools/gatk_variantannotator.cwl
@@ -9,7 +9,7 @@ requirements:
     coresMin: 2
     coresMax: 4
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:3.8_ubuntu'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:3.8_ubuntu'
 baseCommand: [java]
 arguments:
   - position: 1

--- a/tools/gatk_variantfiltration.cwl
+++ b/tools/gatk_variantfiltration.cwl
@@ -9,7 +9,7 @@ requirements:
     coresMin: 2
     coresMax: 4
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
 baseCommand: [/gatk]
 arguments:
   - position: 1

--- a/tools/kfdrc_peddy_tool.cwl
+++ b/tools/kfdrc_peddy_tool.cwl
@@ -7,7 +7,7 @@ requirements:
   - class: ResourceRequirement
     ramMin: 1000
   - class: DockerRequirement
-    dockerPull: 'kfdrc/peddy:latest'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/peddy:latest'
 baseCommand: [python]
 arguments:
   - position: 1

--- a/tools/picard_collectvariantcallingmetrics.cwl
+++ b/tools/picard_collectvariantcallingmetrics.cwl
@@ -5,7 +5,7 @@ requirements:
   - class: InlineJavascriptRequirement
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.0.12.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.0.12.0'
   - class: ResourceRequirement
     ramMin: 7000
     coresMin: 8

--- a/tools/picard_createsequencedictionary.cwl
+++ b/tools/picard_createsequencedictionary.cwl
@@ -7,7 +7,7 @@ doc: |-
   The tool returnts the dict as its only output.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/gatk:4.1.7.0R'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_fasta),$(inputs.input_dict)]
   - class: InlineJavascriptRequirement

--- a/tools/samtools_faidx.cwl
+++ b/tools/samtools_faidx.cwl
@@ -7,7 +7,7 @@ doc: |-
   Finally the tool will return the input reference file with the index (generated or provided) as a secondaryFile.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_fasta),$(inputs.input_index)]
   - class: InlineJavascriptRequirement

--- a/tools/script_dynamicallycombineintervals.cwl
+++ b/tools/script_dynamicallycombineintervals.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: script_dynamicallycombineintervals
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/python:2.7.13'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/python:2.7.13'
   - class: InlineJavascriptRequirement
 hints:
   - class: 'sbg:AWSInstanceType'

--- a/tools/tabix_index.cwl
+++ b/tools/tabix_index.cwl
@@ -6,7 +6,7 @@ doc: >-
   The tool will output the input_file with the index, provided or created within, as a secondary file.
 requirements:
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InitialWorkDirRequirement
     listing: [$(inputs.input_file),$(inputs.input_index)]
   - class: InlineJavascriptRequirement

--- a/tools/variant_effect_predictor.cwl
+++ b/tools/variant_effect_predictor.cwl
@@ -8,7 +8,7 @@ requirements:
     ramMin: 24000
     coresMin: 14
   - class: DockerRequirement
-    dockerPull: 'kfdrc/vep:r93'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/vep:r93'
 baseCommand: [tar, -xzf ]
 arguments:
   - position: 1

--- a/workflow/kfdrc-jointgenotyping-refinement-workflow.cwl
+++ b/workflow/kfdrc-jointgenotyping-refinement-workflow.cwl
@@ -42,7 +42,6 @@ doc: |
       -  wgs_evaluation_regions.hg38.interval_list
 
   ## Other Resources
-  - tool images: https://hub.docker.com/r/kfdrc/
   - dockerfiles: https://github.com/d3b-center/bixtools
 
   ![pipeline flowchart](https://github.com/kids-first/kf-jointgenotyping-workflow/blob/master/docs/kfdrc-jointgenotyping-refinement-workflow.png?raw=true "Joint Genotyping Workflow")
@@ -320,5 +319,5 @@ sbg:categories:
 - VCF
 - VEP
 sbg:links:
-- id: 'https://github.com/kids-first/kf-jointgenotyping-workflow/releases/tag/v2.1.1'
+- id: 'https://github.com/kids-first/kf-jointgenotyping-workflow/releases/tag/v2.2.0'
   label: github-release


### PR DESCRIPTION
## Description

This PR updates the dockerPull statements to the new registry.
It also changes the tag on bwa:0.7.17-dev ot bwa:0.7.17-r1188 which is actually a docker we maintain.

Part of https://github.com/d3b-center/bixu-tracker/issues/846

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/9ad92245-6bf5-4345-9aba-89b572fa924c/

**Test Configuration**:
* Environment: Cavatica
* Test files: see test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
